### PR TITLE
Fixed shaking of the slingshot when mouse2 is pressed

### DIFF
--- a/src/include/api_custom_weapons.inc
+++ b/src/include/api_custom_weapons.inc
@@ -64,7 +64,8 @@ enum CW_Flags (<<=1) {
   CWF_None,
   CWF_NoBulletSmoke = 1,
   CWF_NoBulletDecal,
-  CWF_CustomReload
+  CWF_CustomReload,
+  CWF_NoSecondaryAttack
 }
 
 native CW:CW_Register(const szName[], iWeaponId, iClipSize = WEAPON_NOCLIP, iPrimaryAmmoType = -1, iPrimaryAmmoMaxAmount = -1, iSecondaryAmmoType = -1, iSecondaryAmmoMaxAmount = -1, iSlotId = 0, iPosition = 0, iWeaponFlags = 0, const szIcon[] = "", CW_Flags:iFlags = CWF_None);

--- a/src/scripts/api/api_custom_weapons.sma
+++ b/src/scripts/api/api_custom_weapons.sma
@@ -815,6 +815,7 @@ ItemPostFrame(this) {
     new pPlayer = GetPlayer(this);
     new flInReload = get_member(this, m_Weapon_fInReload);
     new iMaxClip = GetData(iHandler, CW_Data_ClipSize);
+    new CW_Flags:iFlags = GetData(iHandler, CW_Data_Flags);
     new iWeaponFlags = GetData(iHandler, CW_Data_WeaponFlags);
     new Float:flNextAttack = get_member(pPlayer, m_flNextAttack);
     new button = pev(pPlayer, pev_button);
@@ -824,6 +825,10 @@ ItemPostFrame(this) {
     new Float:flNextSecondaryAttack = get_member(this, m_Weapon_flNextSecondaryAttack);
     new iPrimaryAmmoAmount = get_member(pPlayer, m_rgAmmo, iPrimaryAmmoIndex);
     new iSecondaryAmmoAmount = get_member(pPlayer, m_rgAmmo, iSecondaryAmmoIndex);
+
+    if (iFlags & CWF_NoSecondaryAttack) {
+        button &= ~IN_ATTACK2;
+    }
 
     new Float:flReloadEndTime = get_member(this, m_Weapon_flNextReload);
     if (flReloadEndTime && flReloadEndTime < get_gametime()) {

--- a/src/scripts/weapons/sw_weapon_slingshot.sma
+++ b/src/scripts/weapons/sw_weapon_slingshot.sma
@@ -40,7 +40,7 @@ public plugin_precache() {
 public plugin_init() {
   register_plugin(PLUGIN, VERSION, AUTHOR);
 
-  g_iCwHandler = CW_Register("snowwars/v090/weapon_slingshot", CSW_AK47, 1, _, _, _, _, 0, 1, _, "skull", CWF_NoBulletSmoke);
+  g_iCwHandler = CW_Register("snowwars/v090/weapon_slingshot", CSW_AK47, 1, _, _, _, _, 0, 1, _, "skull", CWF_NoBulletSmoke|CWF_NoSecondaryAttack);
   CW_Bind(g_iCwHandler, CWB_Idle, "@Weapon_Idle");
   CW_Bind(g_iCwHandler, CWB_PrimaryAttack, "@Weapon_PrimaryAttack");
   CW_Bind(g_iCwHandler, CWB_Deploy, "@Weapon_Deploy");

--- a/src/scripts/weapons/sw_weapon_snowball.sma
+++ b/src/scripts/weapons/sw_weapon_snowball.sma
@@ -35,7 +35,7 @@ public plugin_precache() {
 public plugin_init() {
   register_plugin(PLUGIN, VERSION, AUTHOR);
 
-  g_iCwHandler = CW_Register("snowwars/v090/weapon_snowball", CSW_DEAGLE, 1, _, _, _, _, 1, 1, _, "skull", CWF_NoBulletSmoke);
+  g_iCwHandler = CW_Register("snowwars/v090/weapon_snowball", CSW_DEAGLE, 1, _, _, _, _, 1, 1, _, "skull", CWF_NoBulletSmoke|CWF_NoSecondaryAttack);
   CW_Bind(g_iCwHandler, CWB_Idle, "@Weapon_Idle");
   CW_Bind(g_iCwHandler, CWB_PrimaryAttack, "@Weapon_PrimaryAttack");
   CW_Bind(g_iCwHandler, CWB_Deploy, "@Weapon_Deploy");


### PR DESCRIPTION
If you hold down the left and right mouse buttons, then the slingshot will not shake the screen. This is because the primary attack (shaking) and idle (throw snowball) events are not called during the right mouse button press. The PR will ignore the right mouse button for the snowball and the slingshot, which will allow idle event to be called correctly.